### PR TITLE
feat: start the mapping from Unreal Engine to Bazel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - run: bazel test //pkg/...
-      - run: bazel build @//:rules-unreal-engine
+      - run: bazel test //:unreal_target_test
+      - run: bazel build //:rules-unreal-engine
 

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load(":rules_test.bzl", "unreal_target_test_suite")
 
 # gazelle:prefix kreempuff.dev/rules-unreal-engine
 gazelle(name = "gazelle")
@@ -26,4 +27,8 @@ go_binary(
     name = "rules-unreal-engine",
     embed = [":rules-unreal-engine_lib"],
     visibility = ["//visibility:public"],
+)
+
+unreal_target_test_suite(
+    name = "unreal_target_test",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,19 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "bazel_skylib",
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+http_archive(
     name = "io_bazel_rules_go",
     sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
     urls = [

--- a/rules.bzl
+++ b/rules.bzl
@@ -1,0 +1,85 @@
+"""
+
+"""
+UnrealModuleInfo = provider(
+    doc = """Module""",
+    fields = ["name"],
+)
+
+def _unreal_target_impl(ctx):
+    target_file = ctx.actions.declare_file(
+        ctx.label.name + ".Target.cs",
+    )
+
+    ctx.actions.write(
+        target_file,
+        content = """
+// Hi
+""",
+    )
+
+    return [DefaultInfo(files = depset([target_file]))]
+
+unreal_target = rule(
+    doc = """
+Attributes for defining a target (application/executable)
+
+https://github.com/EpicGames/UnrealEngine/blob/cdaec5b33ea5d332e51eee4e4866495c90442122/Engine/Source/Programs/UnrealBuildTool/Configuration/TargetRules.cs#L303
+""",
+    implementation = _unreal_target_impl,
+    attrs = {
+        "type": attr.string(
+            doc = """
+Types of target.
+
+game: Cooked monolithic game executable (GameName.exe).  Also used for a game-agnostic engine executable (UnrealGame.exe or RocketGame.exe)
+
+editor: Uncooked modular editor executable and DLLs (UnrealEditor.exe, UnrealEditor*.dll, GameName*.dll)
+
+client: Cooked monolithic game client executable (GameNameClient.exe, but no server code)
+
+server: Cooked monolithic game server executable (GameNameServer.exe, but no client code)
+
+program: Program (standalone program, e.g. ShaderCompileWorker.exe, can be modular or monolithic depending on the program)
+
+- https://github.com/EpicGames/UnrealEngine/blob/cdaec5b33ea5d332e51eee4e4866495c90442122/Engine/Source/Programs/UnrealBuildTool/Configuration/TargetRules.cs#L310
+- https://github.com/EpicGames/UnrealEngine/blob/cdaec5b33ea5d332e51eee4e4866495c90442122/Engine/Source/Programs/UnrealBuildTool/Configuration/TargetRules.cs#L24
+""",
+            values = ["game", "editor", "client", "server", "program"],
+            mandatory = True,
+        ),
+        "default_build_settings": attr.string(
+            doc = """Specifies the engine version to maintain backwards-compatible default build settings with (eg. DefaultSettingsVersion.Release_4_23, DefaultSettingsVersion.Release_4_24). Specify DefaultSettingsVersion.Latest to always
+use defaults for the current engine version, at the risk of introducing build errors while upgrading.
+
+- https://github.com/EpicGames/UnrealEngine/blob/cdaec5b33ea5d332e51eee4e4866495c90442122/Engine/Source/Programs/UnrealBuildTool/Configuration/TargetRules.cs#L461
+- https://github.com/EpicGames/UnrealEngine/blob/cdaec5b33ea5d332e51eee4e4866495c90442122/Engine/Source/Programs/UnrealBuildTool/Configuration/TargetRules.cs#L115
+""",
+            values = ["v1", "v2", "latest"],
+            default = "v2",
+        ),
+        "build_environment": attr.string(
+            doc = """
+The build environment override
+- https://github.com/EpicGames/UnrealEngine/blob/cdaec5b33ea5d332e51eee4e4866495c90442122/Engine/Source/Programs/UnrealBuildTool/Configuration/TargetRules.cs#L1942
+- https://github.com/EpicGames/UnrealEngine/blob/cdaec5b33ea5d332e51eee4e4866495c90442122/Engine/Source/Programs/UnrealBuildTool/Configuration/TargetRules.cs#L76
+            """,
+            values = ["shared", "unique"],
+        ),
+        # TODO(add default module as an attribute)
+        # Watching a YT video on how to create a Unreal project from scratch, I learned that an Unreal Target needs
+        # one default module that invokes special functions that mark it as the primary module. I should expose this as a property. In the meantime, I'm going to expose
+        # what TargetRules expose: a list of "extra modules" to include in this target
+        # Ref: https://youtu.be/94FvzO1HVzY?t=824
+        "extra_module_names": attr.label_list(
+            doc = """
+List of additional modules to be compiled into the target.
+
+- https://github.com/EpicGames/UnrealEngine/blob/cdaec5b33ea5d332e51eee4e4866495c90442122/Engine/Source/Programs/UnrealBuildTool/Configuration/TargetRules.cs#L1920
+""",
+            providers = [UnrealModuleInfo],
+
+            #            cfg = "target", # The modules for a target should be always be built for the target
+        ),
+    },
+)

--- a/rules_test.bzl
+++ b/rules_test.bzl
@@ -1,0 +1,56 @@
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load(":rules.bzl", "unreal_target")
+
+# ==== Check actions ====
+
+def _inspect_actions_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target_under_test = analysistest.target_under_test(env)
+
+    actions = analysistest.target_actions(env)
+    asserts.equals(env, 1, len(actions))
+    action_output = actions[0].outputs.to_list()[0]
+
+    # If preferred, could pass these values as "expected" and "actual" keyword
+    # arguments.
+    asserts.equals(env, target_under_test.label.name + ".Target.cs", action_output.basename)
+
+    # If you forget to return end(), you will get an error about an analysis
+    # test needing to return an instance of AnalysisTestResultInfo.
+    return analysistest.end(env)
+
+# Create the testing rule to wrap the test logic. This must be bound to a global
+# variable, not called in a macro's body, since macros get evaluated at loading
+# time but the rule gets evaluated later, at analysis time. Since this is a test
+# rule, its name must end with "_test".
+inspect_actions_test = analysistest.make(_inspect_actions_test_impl)
+
+# Macro to setup the test.
+def _test_inspect_actions():
+    # Rule under test. Be sure to tag 'manual', as this target should not be
+    # built using `:all` except as a dependency of the test.
+    unreal_target(name = "inspect_actions_subject", tags = ["manual"], type = "game")
+
+    # Testing rule.
+    inspect_actions_test(
+        name = "inspect_actions_test",
+        target_under_test = ":inspect_actions_subject",
+    )
+    # Note the target_under_test attribute is how the test rule depends on
+    # the real rule target.
+
+# Entry point from the BUILD file; macro for running each test case's macro and
+# declaring a test suite that wraps them together.
+def unreal_target_test_suite(name):
+    # Call all test functions and wrap their targets in a suite.
+    _test_inspect_actions()
+    # ...
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":inspect_actions_test",
+            # ...
+        ],
+    )


### PR DESCRIPTION
This begins the process of mapping the Unreal Engine build system to
Bazel. It also adds a simple test to get familiar with the Bazel
testing framework.

References
 - https://bazel.build/rules/testing
