### PR TITLE
feat: use deno to parse git deps xml

### DIFF
--- a/internal/repo/rule.bzl
+++ b/internal/repo/rule.bzl
@@ -6,6 +6,31 @@ def _unreal_engine_impl(repo_ctx):
         fail("Failed to clone Unreal Engine")
     repo_ctx.file("UnrealEngine/BUILD", """exports_files(["Setup.sh"])""")
 
+    version = "v1.30.1"
+    arch = ""
+    os = ""
+
+    if repo_ctx.os.name == "mac os x" and repo_ctx.os.arch == "aarch64":
+        os = "apple-darwin"
+        arch = "aarch64"
+    elif repo_ctx.os.name == "mac os x" and repo_ctx.os.arch == "aarch64":
+        os = "apple-darwin"
+        arch = "x86_64"
+    elif repo_ctx.os.name == "linux" and repo_ctx.os.arch == "x86_64":
+        os = "linux"
+        arch = "x86_64"
+    else:
+        fail("Unsupported operating system and architecture: (" + repo_ctx.os.name + ", " + repo_ctx.os.arch + ")")
+
+    repo_ctx.download_and_extract(
+        url = "https://github.com/denoland/deno/releases/download/{version}/deno-{arch}-{os}.zip".format(version = version, arch = arch, os = os),
+        output = "tools/deno",
+    )
+    repo_ctx.execute(["chmod", "+x", "tools/deno/deno"])
+    repo_ctx.execute(["tools/deno/deno", "run", "--allow-read", "--allow-write", repo_ctx.path(repo_ctx.attr._parse_xml_script), "UnrealEngine/Engine/Build/Commit.gitdeps.xml", "Commit.gitdeps.json"])
+
+#    repo_ctx.execute(["tools/deno/deno", "run", "--allow-read", "--allow-write", "--allow-run", repo_ctx.attr._parse_xml_script.path, "UnrealEngine/Engine/Build/Commit.gitdeps.xml", "Commit.gitdeps.json"])
+
 unreal_engine = repository_rule(
     implementation = _unreal_engine_impl,
     doc = """Downloads and configures an instance of Unreal Engine. Expects `git` to be installed on the system and
@@ -18,6 +43,10 @@ configured to clone Unreal Engine from the given repository""",
         "git_repository": attr.string(
             doc = """The repository to download Unreal Engine from""",
             mandatory = True,
+        ),
+        "_parse_xml_script": attr.label(
+            default = "@//:parse-xml-cli.ts",
+            allow_single_file = True,
         ),
     },
 )

--- a/parse-xml-cli.ts
+++ b/parse-xml-cli.ts
@@ -1,0 +1,17 @@
+import {parseString} from "npm:xml2js";
+
+const decoder = new TextDecoder("utf-8");
+const data = decoder.decode(await Deno.readFile(Deno.args[0]));
+
+parseString(data, (err, result) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+
+    try {
+        Deno.writeTextFileSync(Deno.args[1], JSON.stringify(result, null, 4));
+    } catch (writeErr) {
+        console.error(writeErr);
+    }
+});


### PR DESCRIPTION
I wanted to parse the xml file in but bazel doesn't support using
generated files in repo rules. To get around this I'm using deno to
parse the xml file and generate a json file that I can use to get the urls
for Unreal dependencies.

Deno works because it's a single binary that can be downloaded and it
automatically downloads js dependencies. I'm using the xml2js npm package
to parse the xml file.

I could probably use this directly to generate the urls I need.
