### PR TITLE
docs: extract Phase 1.3 plan to PLAN.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,57 +334,54 @@ When testing features that interact with Unreal Engine source code:
 
 ---
 
-## Phase 1.3: Compiler Toolchain Integration (IN PROGRESS)
+## Phase 1.3: Compiler Toolchain Integration (MOSTLY COMPLETE)
 
-**Branch:** `feat/phase1.3-compiler-toolchain`
 **Started:** 2025-11-01
+**Status:** ~60% complete - Compiler integration done, Core dependencies in progress
 
-### Checklist
+### Major Achievements ✅
 
-**Compiler Flags:**
-- ✅ Extract flags from ClangToolChain.cs
-- ✅ Document in `docs/UE_COMPILER_FLAGS.md`
-- ✅ Add UE default compiler flags (-std=c++20, -fno-exceptions, -fno-rtti, -Wall)
-- ✅ Add UE build configuration defines (UE_BUILD_*, WITH_*, IS_*)
-- ✅ Add platform defines (UBT_COMPILED_PLATFORM, PLATFORM_MAC, etc.)
-- ✅ Add module API macros (CORE_API, ENGINE_API, auto-generated)
-- ✅ Test flags with compile-time validation (TestUEFlags.cpp)
-- 🔲 Validate: Compare Bazel vs UBT output (symbols, binary format)
+- ✅ Full UE compiler integration (C++20, all defines, platform-specific)
+- ✅ ue_modules/ repository architecture (4 modules)
+- ✅ **Circular dependency SOLVED** (Core_headers splitting)
+- ✅ TraceLog compiles successfully
+- ✅ Persistent .test_ue/ test infrastructure
+- ✅ LOCAL_DEV flag for easy testing
+- ✅ Justfile for convenient commands
 
-**Build Core Module:**
-- ✅ Create BUILD.bazel for Core module
-- ✅ Fix include path issues (added Private/ and Internal/ to includes)
-- ✅ Fix missing preprocessor defines (all UE_BUILD_*, WITH_*, platform defines)
-- ✅ Try building Core module (compiles, but needs dependencies)
-- ✅ Resolve Core/TraceLog circular dependency (split Core into Core_headers + Core)
-- ✅ TraceLog now compiles successfully!
-- 🔲 Add LZ4 third-party dependency to TraceLog
-- 🔲 Write BUILD.bazel for other Core dependencies (BuildSettings, GuidelinesSupportLibrary, etc.)
-- 🔲 Get Core to fully compile
-- 🔲 Expected blocker: UHT-generated code (*.generated.h)
+### Remaining Work
 
-**UnrealHeaderTool (UHT) Integration:**
-- 🔲 Build UHT as Bazel target
-- 🔲 Study UHT command-line API
-- 🔲 Create genrule for code generation
-- 🔲 Generate `.generated.h` and `.generated.cpp` files
-- 🔲 Integrate UHT into `ue_module` build flow
-- 🔲 Build CoreUObject (heavily uses UHT reflection)
+See **[docs/PLAN.md](docs/PLAN.md)** for detailed Phase 1.3 task list.
 
-### Key Findings
+**Next priorities:**
+- Add LZ4 third-party dependency to TraceLog
+- Build remaining Core dependencies
+- Get Core to fully compile
+- UHT integration (code generation)
 
-**Compiler Settings (from UBT source):**
-- C++ Standard: C++20
-- Exceptions: OFF (`-fno-exceptions`)
-- RTTI: OFF (`-fno-rtti`)
-- Warnings: `-Wall -Werror`
-- Platform defines: `PLATFORM_MAC=1`, `UE_BUILD_DEVELOPMENT=1`
+### Quick Start
+
+```bash
+# Run tests
+just test-all              # Fast tests
+just test-all-slow         # Including E2E
+
+# Install BUILD files
+just install /path/to/UE
+
+# Build UE modules
+cd /path/to/UE
+bazel build //Engine/Source/ThirdParty/AtomicQueue  # ✅ Works!
+bazel build //Engine/Source/Runtime/TraceLog        # ✅ Compiles (needs LZ4)
+```
 
 ### References
 
-- `docs/UE_COMPILER_FLAGS.md` - Complete flag documentation
-- `ClangToolChain.cs:380-1472` - UBT Clang implementation
-- `test/ue_module.bats` - E2E test template
+- **Task List:** `docs/PLAN.md`
+- **Compiler Flags:** `docs/UE_COMPILER_FLAGS.md`
+- **Module Status:** `ue_modules/README.md`
+- **Test Infrastructure:** `.test_ue/README.md`
+- **Quick Commands:** `justfile`
 
 ---
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,103 @@
+# Phase 1.3 Remaining Work Plan
+
+**Status:** In Progress
+**Last Updated:** 2025-11-01
+
+## Completed ✅
+
+**Compiler Flags:**
+- ✅ Extract flags from ClangToolChain.cs
+- ✅ Document in `docs/UE_COMPILER_FLAGS.md`
+- ✅ Add UE default compiler flags (-std=c++20, -fno-exceptions, -fno-rtti, -Wall)
+- ✅ Add UE build configuration defines (UE_BUILD_*, WITH_*, IS_*)
+- ✅ Add platform defines (UBT_COMPILED_PLATFORM, PLATFORM_MAC, etc.)
+- ✅ Add module API macros (CORE_API, ENGINE_API, auto-generated)
+- ✅ Test flags with compile-time validation (TestUEFlags.cpp)
+
+**Build Core Module:**
+- ✅ Create BUILD.bazel for Core module
+- ✅ Fix include path issues (added Private/ and Internal/ to includes)
+- ✅ Fix missing preprocessor defines (all UE_BUILD_*, WITH_*, platform defines)
+- ✅ Try building Core module (compiles, but needs dependencies)
+- ✅ **Resolve Core/TraceLog circular dependency** (split Core into Core_headers + Core)
+- ✅ **TraceLog compiles successfully!**
+
+## To Do 🔲
+
+### Build Core Module (Continued)
+
+**Immediate:**
+- 🔲 Add LZ4 third-party dependency to TraceLog
+  - Find LZ4 in Engine/Source/ThirdParty/
+  - Create ue_modules/ThirdParty/LZ4/BUILD.bazel
+  - Add to TraceLog deps
+  - Validate TraceLog builds completely
+
+**Core Dependencies:**
+- 🔲 Write BUILD.bazel for GuidelinesSupportLibrary
+- 🔲 Write BUILD.bazel for BuildSettings
+- 🔲 Write BUILD.bazel for AutoRTFM
+- 🔲 Write BUILD.bazel for BLAKE3
+- 🔲 Write BUILD.bazel for OodleDataCompression
+- 🔲 Write BUILD.bazel for xxhash
+- 🔲 Platform-specific: mimalloc, IntelTBB, jemalloc, PLCrashReporter
+
+**Core Compilation:**
+- 🔲 Add all Core dependencies to Core BUILD.bazel
+- 🔲 Try building Core with all dependencies
+- 🔲 Fix any remaining compilation errors
+- 🔲 Expected blocker: UHT-generated code (*.generated.h)
+
+### UnrealHeaderTool (UHT) Integration
+
+- 🔲 Build UHT as Bazel target
+  - UHT is in Engine/Source/Programs/UnrealHeaderTool
+  - Has its own dependencies
+  - Needs Core, CoreUObject to be built first (chicken-egg!)
+
+- 🔲 Study UHT command-line API
+  - How to invoke UHT
+  - What files it needs (manifests, headers)
+  - What it generates (.generated.h, .generated.cpp)
+
+- 🔲 Create genrule for code generation
+  - Run UHT before C++ compilation
+  - Generate reflection code
+  - Make generated files available to module compilation
+
+- 🔲 Integrate UHT into `ue_module` build flow
+  - Detect modules with UCLASS/UPROPERTY
+  - Auto-run UHT genrule
+  - Include generated code in srcs
+
+- 🔲 Build CoreUObject (heavily uses UHT reflection)
+  - First module to fully test UHT integration
+  - Has many UCLASS/UPROPERTY macros
+
+### Validation
+
+- 🔲 Compare Bazel vs UBT output (symbols, binary format)
+  - Build Core with UBT
+  - Build Core with Bazel
+  - Compare with nm -g (symbol exports)
+  - Verify compatibility
+
+## Current Branch
+
+Working on main - all Phase 1.3 work merged!
+
+Next work will likely be:
+- Branch: `feat/phase1.3-lz4-and-core-deps`
+- Focus: Build all Core dependencies
+- Goal: Core module fully compiles
+
+## References
+
+- Phase 1.3 Compiler Flags: `docs/UE_COMPILER_FLAGS.md`
+- UE Modules: `ue_modules/Runtime/Core/BUILD.bazel`
+- Test Infrastructure: `.test_ue/README.md`
+- Quick Commands: `justfile`
+
+---
+
+**Progress:** Phase 1.3 is ~60% complete (compiler integration done, Core dependencies in progress)


### PR DESCRIPTION
## Summary

Refactor documentation to separate project context from detailed work plan.

## Changes

**New file: docs/PLAN.md**
- Detailed Phase 1.3 task checklist
- Completed vs remaining work
- Clear categorization (compiler flags, Core build, UHT)
- Next branch suggestions
- Progress tracking: ~60% complete

**Updated: CLAUDE.md**
- References docs/PLAN.md for detailed tasks
- Keeps high-level achievements and status
- Adds Quick Start section with justfile commands
- Cleaner, more focused project context

## Why

**Before:** CLAUDE.md mixed project history with current task tracking
**After:** 
- CLAUDE.md = Why this project exists + high-level status
- PLAN.md = What to do next (detailed checklist)

This makes it easier to:
- Understand the project (CLAUDE.md)
- Resume work (PLAN.md)
- Track progress

## File Roles

- `CLAUDE.md` - Project context, motivation, high-level status
- `docs/PLAN.md` - Current work plan and detailed checklist  
- `docs/effort-estimate.md` - Long-term roadmap
- `docs/UE_COMPILER_FLAGS.md` - Technical reference