### PR TITLE
Core 98.6% + Auto-Headers Feature

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bazel cquery:*)",
+      "Bash(bazel build:*)",
+      "Bash(just install:*)",
+      "Bash(bazel test:*)",
+      "Bash(just test-all:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/bzl/module.bzl
+++ b/bzl/module.bzl
@@ -336,6 +336,17 @@ def ue_module(
         "ue_module_type:" + module_type,
     ]
 
+    # Create headers-only target (for circular dependencies and faster compiles)
+    # Every ue_module automatically gets a {name}_headers target
+    cc_library(
+        name = name + "_headers",
+        hdrs = hdrs,
+        includes = includes,
+        defines = all_defines,  # Public defines (no local_defines - those are private)
+        visibility = visibility,
+        tags = tags + ["headers_only"],
+    )
+
     # Create the main cc_library (C++ files only, C files in separate library)
     cc_library(
         name = name,

--- a/bzl/module.bzl
+++ b/bzl/module.bzl
@@ -211,6 +211,7 @@ def ue_module(
         "WITH_SERVER_CODE=1",             # Include server code (for dedicated servers)
         "IS_MONOLITHIC=0",                # Modular build
         "IS_PROGRAM=0",                   # Not a standalone program
+        "UE_GAME=1",                      # Game build (not editor/server/client/program)
         "TBBMALLOC_ENABLED=0",            # Disable Intel TBB malloc (platform-specific)
         "USE_MALLOC_BINNED2=1",           # Use Binned2 allocator (UE default)
         "USE_MALLOC_BINNED3=0",           # Binned3 experimental allocator OFF

--- a/ue_modules/Runtime/Core/BUILD.bazel
+++ b/ue_modules/Runtime/Core/BUILD.bazel
@@ -49,8 +49,6 @@ ue_module(
         "//Engine/Source/Runtime/BuildSettings",
         "//Engine/Source/Runtime/AutoRTFM",
         "//Engine/Source/Runtime/Launch",  # Minimal header-only (just Version.h)
-        "//Engine/Source/Runtime/ImageCore",  # Minimal header-only
-        "//Engine/Source/Developer/TargetPlatform",  # Minimal header-only
         "//Engine/Source/ThirdParty/BLAKE3",
         "//Engine/Source/Runtime/OodleDataCompression",
         "//Engine/Source/ThirdParty/xxhash",

--- a/ue_modules/Runtime/Core/BUILD.bazel
+++ b/ue_modules/Runtime/Core/BUILD.bazel
@@ -62,23 +62,17 @@ ue_module(
     module_type = "Runtime",
 
     # Unity build pattern: lz4.cpp is included by lz4hc.cpp, not compiled separately
-    # Temporarily exclude problematic files
+    # Exclude files requiring other modules to be fully built (7 remaining)
     exclude_srcs = [
         "Private/Compression/lz4.cpp",  # Unity build: included by lz4hc.cpp
         "Private/HAL/ConsoleManager.cpp",  # TODO: Fix FConsoleManager header visibility
-        "Private/HAL/MallocTBB.cpp",  # TODO: Add IntelTBB dependency
+        "Private/HAL/MallocTBB.cpp",  # TODO: Build IntelTBB module
         "Private/HAL/MallocJemalloc.cpp",  # Linux-specific allocator
         "Private/HAL/MallocMimalloc.cpp",  # Windows/Linux allocator
-        # Files needing Runtime/Launch/Resources/Version.h
-        "Private/Misc/App.cpp",
-        "Private/Misc/ConfigManifest.cpp",
-        "Private/Misc/EngineVersion.cpp",
-        "Private/FramePro/FrameProProfiler.cpp",
-        # Other module dependencies
-        "Private/Misc/CoreMisc.cpp",  # TODO: Needs DerivedDataCache module
-        "Private/Misc/ObjectThumbnail.cpp",  # TODO: Needs ImageCore module
-        "Private/Serialization/Archive.cpp",  # TODO: Needs TargetPlatform module
-        "Private/Serialization/MemoryImage.cpp",  # TODO: Needs TargetPlatform module
+        "Private/Misc/CoreMisc.cpp",  # TODO: Build DerivedDataCache module (needs DERIVEDDATACACHE_API)
+        "Private/Misc/ObjectThumbnail.cpp",  # TODO: Build ImageCore module (needs IMAGECORE_API)
+        "Private/Serialization/Archive.cpp",  # TODO: Build TargetPlatform module (needs TARGETPLATFORM_API)
+        "Private/Serialization/MemoryImage.cpp",  # TODO: Build TargetPlatform module
     ],
     additional_hdrs = ["Private/Compression/lz4.cpp"],  # Unity build: included by lz4hc.cpp
 
@@ -95,6 +89,9 @@ ue_module(
     private_deps = [
         "//Engine/Source/Runtime/BuildSettings",
         "//Engine/Source/Runtime/AutoRTFM",
+        "//Engine/Source/Runtime/Launch",  # Minimal header-only (just Version.h)
+        "//Engine/Source/Runtime/ImageCore",  # Minimal header-only
+        "//Engine/Source/Developer/TargetPlatform",  # Minimal header-only
         "//Engine/Source/ThirdParty/BLAKE3",
         "//Engine/Source/Runtime/OodleDataCompression",
         "//Engine/Source/ThirdParty/xxhash",

--- a/ue_modules/Runtime/Core/BUILD.bazel
+++ b/ue_modules/Runtime/Core/BUILD.bazel
@@ -14,49 +14,8 @@ Converted from: Engine/Source/Runtime/Core/Core.Build.cs
 load("@rules_unreal_engine//bzl:module.bzl", "ue_module")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
-# Core headers-only target (breaks circular dependency with TraceLog)
-cc_library(
-    name = "Core_headers",
-    hdrs = glob(
-        [
-            "Public/**/*.h",
-            "Public/**/*.hpp",
-            "Public/**/*.inl",
-            "Internal/**/*.h",
-            "Private/**/*.h",
-        ],
-        allow_empty = True,
-    ),
-    includes = ["Public", "Internal", "Private"],
-    defines = [
-        "UE_BUILD_DEVELOPMENT=1",
-        "UE_BUILD_DEBUG=0",
-        "UE_BUILD_TEST=0",
-        "UE_BUILD_SHIPPING=0",
-        "WITH_EDITOR=0",
-        "WITH_ENGINE=1",
-        "WITH_UNREAL_DEVELOPER_TOOLS=0",
-        "WITH_PLUGIN_SUPPORT=1",
-        "IS_MONOLITHIC=0",
-        "IS_PROGRAM=0",
-        "CORE_API=",
-    ] + select({
-        "@platforms//os:macos": [
-            "UBT_COMPILED_PLATFORM=Mac",
-            "PLATFORM_MAC=1",
-            "PLATFORM_APPLE=1",
-        ],
-        "@platforms//os:linux": [
-            "UBT_COMPILED_PLATFORM=Linux",
-            "PLATFORM_LINUX=1",
-            "PLATFORM_UNIX=1",
-        ],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-)
-
-# Full Core module (implementation)
+# Core module
+# Note: Core_headers is now auto-created by ue_module (all modules get _headers targets)
 ue_module(
     name = "Core",
     module_type = "Runtime",

--- a/ue_modules/Runtime/Launch/BUILD.bazel
+++ b/ue_modules/Runtime/Launch/BUILD.bazel
@@ -1,0 +1,22 @@
+# Launch Module (minimal - header-only for Version.h)
+# Full Launch module has massive dependencies (Engine, Slate, RHI, etc.)
+# For now, just expose Resources/Version.h for Core files that need it
+# Location: Engine/Source/Runtime/Launch
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Minimal header-only target for Version.h
+# Full Launch module will be built later when dependencies exist
+cc_library(
+    name = "Launch",
+
+    # Only expose Resources/Version.h for now
+    hdrs = ["Resources/Version.h"],
+
+    # Make accessible via "Runtime/Launch/Resources/Version.h" include style
+    includes = ["../.."],  # Engine/Source
+
+    visibility = ["//visibility:public"],
+
+    tags = ["launch", "minimal", "header-only"],
+)


### PR DESCRIPTION
**Major improvements:**

1. **Auto-headers:** Every ue_module creates {name}_headers automatically
2. **Launch module:** Minimal stub enables 4 new Core files
3. **Core 98.6%:** 507/514 files compile (up from 503)

**Clean build:** 62 seconds, libCore.a ✅

**Benefits:**
- Simpler BUILD files (-40 lines in Core)
- Circular dependencies solved by default
- Consistent pattern for all modules

**Remaining:** 7 files need full modules (ImageCore, TargetPlatform, etc.)